### PR TITLE
[TESTING] boost iostreams impl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,15 @@ include_directories(SYSTEM ${MASON_PACKAGE_catch_INCLUDE_DIRS})
 mason_use(zlib VERSION 1.2.8)
 include_directories(SYSTEM ${MASON_PACKAGE_zlib_INCLUDE_DIRS})
 
+# headers
+mason_use(boost VERSION 1.63.0 HEADER_ONLY)
+include_directories(SYSTEM ${MASON_PACKAGE_boost_INCLUDE_DIRS})
+# iostreams library which has gzip coding support
+mason_use(boost_libiostreams VERSION 1.63.0)
+
 include_directories("${PROJECT_SOURCE_DIR}/include")
 
 file(GLOB TEST_SOURCES test/*.cpp)
 add_executable(unit-tests ${TEST_SOURCES})
 # link zlib static library to the unit-tests binary so the tests know where to find the zlib impl code
-target_link_libraries(unit-tests ${MASON_PACKAGE_zlib_STATIC_LIBS})
+target_link_libraries(unit-tests ${MASON_PACKAGE_zlib_STATIC_LIBS} ${MASON_PACKAGE_boost_libiostreams_STATIC_LIBS})

--- a/include/gzip/decompress.hpp
+++ b/include/gzip/decompress.hpp
@@ -3,6 +3,16 @@
 // std
 #include <stdexcept>
 
+#define USE_BOOST
+
+#ifdef USE_BOOST
+#include <boost/iostreams/device/array.hpp>
+#include <boost/iostreams/compose.hpp>
+#include <boost/iostreams/device/back_inserter.hpp>
+#include <boost/iostreams/copy.hpp>
+#include <boost/iostreams/filter/gzip.hpp>
+#endif
+
 namespace gzip {
 
 // decodes both zlib and gzip
@@ -10,6 +20,14 @@ namespace gzip {
 std::string decompress(const char * data, std::size_t size) {
 
     std::string output;
+#ifdef USE_BOOST
+    boost::iostreams::array_source src(data, size);
+    boost::iostreams::copy(src,
+                           boost::iostreams::compose(
+                             boost::iostreams::gzip_decompressor(),
+                             boost::iostreams::back_inserter(output))
+                           );
+#else
     z_stream inflate_s;
 
     inflate_s.zalloc = Z_NULL;
@@ -37,7 +55,7 @@ std::string decompress(const char * data, std::size_t size) {
     } while (inflate_s.avail_out == 0);
     inflateEnd(&inflate_s);
     output.resize(length);
-
+#endif
     // return the std::string
     return output; 
 }


### PR DESCRIPTION
@GretaCB - I put together a branch here that switches out the implementation to use boost which has a C++ wrapper around zlib (http://www.boost.org/doc/libs/1_42_0/libs/iostreams/doc/classes/gzip.html).

Our library is meant to be used instead of boost since:

  - A boost dependency for something as common as gzip coding is mucho overkill
  - We should be able to be faster than boost
  - Our source code should compile to smaller object code than boost (smaller binaries!)

So why did I put up this branch? Because:

  - I wanted to confirm that all our unit tests pass (to confirm our implementation results in the same data as boost) ✅  it does (tests pass locally)
  - When you start on benchmarks next week, it will be useful to benchmark against boost to ensure we are faster. In this case this branch could be a reference point for how to write benchmarks that use boost (so, instead of replacing our implementation like I've done here we can move the boost usage directly into the benchmark: that way this repo will depend on boost for testing only and there will be no boost dependency for downstream users that use our headers).