### PR TITLE
Integrate clang-tidy and clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,88 @@
+---
+# Mapbox.Variant C/C+ style
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit:     0
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          Never

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,27 @@
+---
+Checks:          '*,-cert-err58-cpp'
+WarningsAsErrors: '*'
+HeaderFilterRegex: '\/include\/'
+AnalyzeTemporaryDtors: false
+CheckOptions:    
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+...

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build
 *.profdata
 *.profraw
 .toolchain
+.mason
+local.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,15 @@ matrix:
           packages: [ 'libstdc++6', 'libstdc++-5-dev' ]
     - os: osx
       osx_image: xcode8.3
+    # clang-tidy specific job
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources: [ 'ubuntu-toolchain-r-test' ]
+          packages: [ 'libstdc++6', 'libstdc++-5-dev' ]
+      script:
+        - make tidy
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,16 +33,16 @@ matrix:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6', 'libstdc++-5-dev' ]
       script:
+        # First run the clang-tidy target
+        # This target does not currently return non-zero when problems
+        # are fixed, but rather it fixes automatically. Changed files
+        # will be detected by the format target and will trigger an error
         - make tidy
-    # Clang format build
-    - os: linux
-      sudo: false
-      addons:
-        apt:
-          sources: [ 'ubuntu-toolchain-r-test' ]
-          packages: [ 'libstdc++6', 'libstdc++-5-dev' ]
-      script:
+        # Now we run the clang-format script. Any code formatting changes
+        # will trigger the build to fail (idea here is to get us to pay attention
+        # and get in the habit of running these locally before committing)
         - make format
+
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,14 @@ matrix:
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
-          packages: [ 'libstdc++6', 'libstdc++-5-dev' ]
+          packages: [ 'libstdc++-5-dev' ]
     - os: linux
       sudo: false
       env: CXX=clang++ CXXFLAGS="-fsanitize=address,undefined -fno-sanitize-recover=all"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
-          packages: [ 'libstdc++6', 'libstdc++-5-dev' ]
+          packages: [ 'libstdc++-5-dev' ]
     - os: osx
       osx_image: xcode8.3
     # clang-tidy specific job
@@ -31,7 +31,7 @@ matrix:
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
-          packages: [ 'libstdc++6', 'libstdc++-5-dev' ]
+          packages: [ 'libstdc++-5-dev' ]
       script:
         # First run the clang-tidy target
         # This target does not currently return non-zero when problems

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,15 @@ matrix:
           packages: [ 'libstdc++6', 'libstdc++-5-dev' ]
       script:
         - make tidy
+    # Clang format build
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources: [ 'ubuntu-toolchain-r-test' ]
+          packages: [ 'libstdc++6', 'libstdc++-5-dev' ]
+      script:
+        - make format
 
 env:
   global:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.8)
 project(hpp_skel LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/mason.cmake)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Code Formatting
+
+We use [this script](/scripts/format.sh#L20) to install a consistent version of [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) to format the code base. The format is automatically checked via a Travis CI build as well. Run the following script locally to ensure formatting is ready to merge:
+
+    make format
+
+We also use [`clang-tidy`](https://clang.llvm.org/extra/clang-tidy/) as a C++ linter. Run the following command to lint and ensure your code is ready to merge:
+
+	make tidy

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ coverage:
 tidy:
 	./scripts/clang-tidy.sh
 
+format:
+	./scripts/format.sh
+
 clean:
 	rm -rf build
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ bench:
 coverage:
 	./scripts/coverage.sh
 
+tidy:
+	./scripts/clang-tidy.sh
+
 clean:
 	rm -rf build
 

--- a/bench/run.cpp
+++ b/bench/run.cpp
@@ -1,6 +1,6 @@
 #include <benchmark/benchmark.h>
-#include <gzip.hpp>
 #include <fstream>
+#include <gzip.hpp>
 
 auto BM_compress = [](benchmark::State& state, const char * data, size_t length) // NOLINT google-runtime-references
 {

--- a/include/gzip.hpp
+++ b/include/gzip.hpp
@@ -3,7 +3,7 @@
  * gzip implements a standard namespace with a few available functions.
  */
 
-#include "gzip/version.hpp"
 #include "gzip/compress.hpp"
 #include "gzip/decompress.hpp"
 #include "gzip/utils.hpp"
+#include "gzip/version.hpp"

--- a/include/gzip/compress.hpp
+++ b/include/gzip/compress.hpp
@@ -2,18 +2,19 @@
 // zlib
 #include <zlib.h>
 // std
-#include <stdexcept>
 #include <limits>
+#include <stdexcept>
 
 namespace gzip {
 
 static const unsigned long MAX_SIZE_BEFORE_COMPRESS = 2000000000; // 2GB decompressed
 
 // Compress method that takes a pointer an immutable character sequence (aka a string in C)
-std::string compress (const char * data,
-                      std::size_t size,
-                      int level=Z_DEFAULT_COMPRESSION, 
-                      int strategy=Z_DEFAULT_STRATEGY) {
+std::string compress(const char* data,
+                     std::size_t size,
+                     int level = Z_DEFAULT_COMPRESSION,
+                     int strategy = Z_DEFAULT_STRATEGY)
+{
 
     std::string output;
     z_stream deflate_s;
@@ -23,23 +24,25 @@ std::string compress (const char * data,
     deflate_s.opaque = Z_NULL;
     deflate_s.avail_in = 0;
     deflate_s.next_in = Z_NULL;
-    
+
     // 4th arg is 31 because of...? Also what tippecanoe is doing
     // TODO: double check this
     if (deflateInit2(&deflate_s, level, Z_DEFLATED, 31, 8, strategy) != Z_OK)
     {
         throw std::runtime_error("deflate init failed");
     }
-    deflate_s.next_in = (Bytef *)data;
-    
+    deflate_s.next_in = (Bytef*)data;
+
 #ifdef DEBUG
     // Verify if size input will fit into unsigned int, type used for zlib's avail_in
-    if (size > std::numeric_limits<unsigned int>::max()) {
+    if (size > std::numeric_limits<unsigned int>::max())
+    {
         deflateEnd(&deflate_s); // explicitly end deflate to avoid memory leak
         throw std::runtime_error("size arg is too large to fit into unsigned int type");
     }
 #endif
-    if (size > MAX_SIZE_BEFORE_COMPRESS) {
+    if (size > MAX_SIZE_BEFORE_COMPRESS)
+    {
         deflateEnd(&deflate_s); // explicitly end deflate to avoid memory leak
         throw std::runtime_error("size may use more memory than intended when decompressing");
     }
@@ -47,15 +50,16 @@ std::string compress (const char * data,
     deflate_s.avail_in = static_cast<unsigned int>(size);
 
     size_t length = 0;
-    do {
+    do
+    {
         size_t increase = size / 2 + 1024;
         output.resize(length + increase);
         // There is no way we see that "increase" would not fit in an unsigned int,
         // hence we use static cast here to avoid -Wshorten-64-to-32 error
         deflate_s.avail_out = static_cast<unsigned int>(increase);
-        deflate_s.next_out = (Bytef *)(output.data() + length);
+        deflate_s.next_out = (Bytef*)(output.data() + length);
         // From http://www.zlib.net/zlib_how.html
-        // "deflate() has a return value that can indicate errors, yet we do not check it here. 
+        // "deflate() has a return value that can indicate errors, yet we do not check it here.
         // Why not? Well, it turns out that deflate() can do no wrong here."
         // Basically only possible error is from deflateInit not working properly
         deflate(&deflate_s, Z_FINISH);
@@ -63,10 +67,9 @@ std::string compress (const char * data,
     } while (deflate_s.avail_out == 0);
     deflateEnd(&deflate_s);
     output.resize(length);
-    
-    // return the std::string
-    return output; 
-}
 
+    // return the std::string
+    return output;
+}
 
 } // end gzip namespace

--- a/include/gzip/decompress.hpp
+++ b/include/gzip/decompress.hpp
@@ -1,8 +1,8 @@
 // zlib
 #include <zlib.h>
 // std
-#include <stdexcept>
 #include <limits>
+#include <stdexcept>
 
 namespace gzip {
 
@@ -10,7 +10,8 @@ static const unsigned long MAX_SIZE_BEFORE_DECOMPRESS = 1000000000; // 1GB compr
 
 // decodes both zlib and gzip
 // http://stackoverflow.com/a/1838702/2333354
-std::string decompress(const char * data, std::size_t size) {
+std::string decompress(const char* data, std::size_t size)
+{
 
     std::string output;
     z_stream inflate_s;
@@ -24,26 +25,29 @@ std::string decompress(const char * data, std::size_t size) {
     {
         throw std::runtime_error("inflate init failed");
     }
-    inflate_s.next_in = (Bytef *)data;
+    inflate_s.next_in = (Bytef*)data;
 
 #ifdef DEBUG
     // Verify if size (long type) input will fit into unsigned int, type used for zlib's avail_in
-    std::uint64_t size_64 = size * 2;     
-    if (size_64 > std::numeric_limits<unsigned int>::max()) {
+    std::uint64_t size_64 = size * 2;
+    if (size_64 > std::numeric_limits<unsigned int>::max())
+    {
         inflateEnd(&inflate_s);
         throw std::runtime_error("size arg is too large to fit into unsigned int type x2");
     }
-#endif 
-    if (size > MAX_SIZE_BEFORE_DECOMPRESS) {
+#endif
+    if (size > MAX_SIZE_BEFORE_DECOMPRESS)
+    {
         inflateEnd(&inflate_s);
         throw std::runtime_error("size may use more memory than intended when decompressing");
-    }   
+    }
     inflate_s.avail_in = static_cast<unsigned int>(size);
     size_t length = 0;
-    do {
+    do
+    {
         output.resize(length + 2 * size);
         inflate_s.avail_out = static_cast<unsigned int>(2 * size);
-        inflate_s.next_out = (Bytef *)(output.data() + length);
+        inflate_s.next_out = (Bytef*)(output.data() + length);
         int ret = inflate(&inflate_s, Z_FINISH);
         if (ret != Z_STREAM_END && ret != Z_OK && ret != Z_BUF_ERROR)
         {
@@ -58,7 +62,7 @@ std::string decompress(const char * data, std::size_t size) {
     output.resize(length);
 
     // return the std::string
-    return output; 
+    return output;
 }
 
 } // end gzip namespace

--- a/include/gzip/utils.hpp
+++ b/include/gzip/utils.hpp
@@ -1,23 +1,19 @@
 namespace gzip {
-    // These live in gzip.hpp because it doesnt need to use deps. 
-    // Otherwise, they would need to live in impl files if these methods used 
-    // zlib structures or functions like inflate/deflate)
-    inline bool is_compressed(const char * data, std::size_t size)
-    {
-        return size > 2 && 
-            (
-        		// zlib
-        		(
-        			static_cast<uint8_t>(data[0]) == 0x78 &&
-        			(
-        				static_cast<uint8_t>(data[1]) == 0x9C || 
-        			 	static_cast<uint8_t>(data[1]) == 0x01 || 
-               	     	static_cast<uint8_t>(data[1]) == 0xDA || 
-                     	static_cast<uint8_t>(data[1]) == 0x5E
-                    )
-                 ) ||
-        		 // gzip
-        		(static_cast<uint8_t>(data[0]) == 0x1F && static_cast<uint8_t>(data[1]) == 0x8B)
-        	);
-    }    
+// These live in gzip.hpp because it doesnt need to use deps.
+// Otherwise, they would need to live in impl files if these methods used
+// zlib structures or functions like inflate/deflate)
+inline bool is_compressed(const char* data, std::size_t size)
+{
+    return size > 2 &&
+           (
+               // zlib
+               (
+                   static_cast<uint8_t>(data[0]) == 0x78 &&
+                   (static_cast<uint8_t>(data[1]) == 0x9C ||
+                    static_cast<uint8_t>(data[1]) == 0x01 ||
+                    static_cast<uint8_t>(data[1]) == 0xDA ||
+                    static_cast<uint8_t>(data[1]) == 0x5E)) ||
+               // gzip
+               (static_cast<uint8_t>(data[0]) == 0x1F && static_cast<uint8_t>(data[1]) == 0x8B));
+}
 }

--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+# https://clang.llvm.org/extra/clang-tidy/
+
+# to speed up re-runs, only re-create environment if needed
+if [[ ! -f local.env ]]; then
+    # automatically setup environment
+    ./scripts/setup.sh --config local.env
+fi
+
+# source the environment
+source local.env
+
+PATH_TO_CLANG_TIDY_SCRIPT="$(pwd)/mason_packages/.link/share/run-clang-tidy.py"
+
+# to speed up re-runs, only install clang-tidy if needed
+if [[ ! -f PATH_TO_CLANG_TIDY_SCRIPT ]]; then
+    # The MASON_LLVM_RELEASE variable comes from `local.env`
+    mason install clang-tidy ${MASON_LLVM_RELEASE}
+    # We link the tools to make it easy to know ${PATH_TO_CLANG_TIDY_SCRIPT}
+    mason link clang-tidy ${MASON_LLVM_RELEASE}
+fi
+
+# build the compile_commands.json file if it does not exist
+if [[ ! -f build/compile_commands.json ]]; then
+    # the build automatically puts the compile commands in the ./build directory
+    make
+
+fi
+
+# change into the build directory so that clang-tidy can find the files
+# at the right paths (since this is where the actual build happens)
+cd build
+${PATH_TO_CLANG_TIDY_SCRIPT} -fix

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+: '
+
+Runs clang-format on the code in include/
+
+Return `1` if there are files to be formatted, and automatically formats them.
+
+Returns `0` if everything looks properly formatted.
+
+'
+ # Set up the environment by installing mason and clang++
+./scripts/setup.sh --config local.env
+source local.env
+
+# Add clang-format as a dep
+mason install clang-format ${MASON_LLVM_RELEASE}
+mason link clang-format ${MASON_LLVM_RELEASE}
+
+# Run clang-format on all cpp and hpp files in the /src directory
+find include/ -type f -name '*.hpp' \
+ | xargs -I{} clang-format -i -style=file {}
+
+# Print list of modified files
+dirty=$(git ls-files --modified include/)
+
+if [[ $dirty ]]; then
+    echo "The following files have been modified:"
+    echo $dirty
+    exit 1
+else
+    exit 0
+fi

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -30,6 +30,7 @@ dirty=$(git ls-files --modified include/)
 if [[ $dirty ]]; then
     echo "The following files have been modified:"
     echo $dirty
+    git diff
     exit 1
 else
     exit 0

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -21,7 +21,7 @@ mason install clang-format ${MASON_LLVM_RELEASE}
 mason link clang-format ${MASON_LLVM_RELEASE}
 
 # Run clang-format on all cpp and hpp files in the /src directory
-find include/ -type f -name '*.hpp' \
+find include/ test/ -type f -name '*.hpp'  -or -name '*.cpp' \
  | xargs -I{} clang-format -i -style=file {}
 
 # Print list of modified files

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -6,72 +6,76 @@
 #include <catch.hpp>
 #include <limits>
 
-TEST_CASE("test version") {
+TEST_CASE("test version")
+{
     REQUIRE(GZIP_VERSION_STRING == std::string("1.0.0"));
 }
 
-TEST_CASE("successful compress - pointer") {
+TEST_CASE("successful compress - pointer")
+{
     std::string data = "hello hello hello hello";
-    const char * pointer = data.data();
+    const char* pointer = data.data();
 
     std::string value = gzip::compress(pointer, data.size());
     REQUIRE(!value.empty());
 }
 
-TEST_CASE("fail compress - throws max size limit") {
+TEST_CASE("fail compress - throws max size limit")
+{
     std::string data = "hello hello hello hello";
-    const char * pointer = data.data();
+    const char* pointer = data.data();
 
-    unsigned long l = 2000000001; 
+    unsigned long l = 2000000001;
 
     CHECK_THROWS_WITH(gzip::compress(pointer, l), Catch::Contains("size may use more memory than intended when decompressing"));
 }
 
 #ifdef DEBUG
-TEST_CASE("fail compress - pointer, debug throws int overflow") {
+TEST_CASE("fail compress - pointer, debug throws int overflow")
+{
     std::string data = "hello hello hello hello";
-    const char * pointer = data.data();
+    const char* pointer = data.data();
     // numeric_limit useful for integer conversion
     unsigned int i = std::numeric_limits<unsigned int>::max();
     // turn int i into a long, so we can add to it safely without overflow
-    unsigned long l = static_cast<unsigned long>(i) + 1; 
-    
-    CHECK_THROWS_WITH(gzip::compress(pointer, l), Catch::Contains("size arg is too large to fit into unsigned int type"));
+    unsigned long l = static_cast<unsigned long>(i) + 1;
 
+    CHECK_THROWS_WITH(gzip::compress(pointer, l), Catch::Contains("size arg is too large to fit into unsigned int type"));
 }
 #endif
 
-TEST_CASE("successful decompress - pointer") {
+TEST_CASE("successful decompress - pointer")
+{
     std::string data = "hello hello hello hello";
-    const char * pointer = data.data();
+    const char* pointer = data.data();
     std::string compressed_data = gzip::compress(pointer, data.size());
-    const char * compressed_pointer = compressed_data.data();
+    const char* compressed_pointer = compressed_data.data();
 
     std::string value = gzip::decompress(compressed_pointer, data.size());
     REQUIRE(data == value);
 }
 
 #ifdef DEBUG
-TEST_CASE("fail decompress - pointer, debug throws int overflow") {
+TEST_CASE("fail decompress - pointer, debug throws int overflow")
+{
     std::string data = "hello hello hello hello";
-    const char * pointer = data.data();
+    const char* pointer = data.data();
     std::string compressed_data = gzip::compress(pointer, data.size());
-    const char * compressed_pointer = compressed_data.data();
+    const char* compressed_pointer = compressed_data.data();
 
     // numeric_limit useful for integer conversion
     unsigned int i = std::numeric_limits<unsigned int>::max();
     // turn int i into a long, so we can add to it safely without overflow
-    unsigned long l = static_cast<unsigned long>(i) + 1; 
-    
+    unsigned long l = static_cast<unsigned long>(i) + 1;
+
     CHECK_THROWS_WITH(gzip::decompress(compressed_pointer, l), Catch::Contains("size arg is too large to fit into unsigned int type x2"));
 }
 #endif
 
-
 TEST_CASE("invalid decompression")
 {
     std::string data("this is a string that should be compressed data");
-    const char * pointer = data.data();
+    const char* pointer = data.data();
     // data is not compressed but we will try to decompress it
 
     CHECK_THROWS(gzip::decompress(pointer, data.size()));
@@ -80,10 +84,10 @@ TEST_CASE("invalid decompression")
 TEST_CASE("round trip compression - gzip")
 {
     const std::string data("this is a sentence that will be compressed into something");
-    const char * pointer = data.data();
+    const char* pointer = data.data();
 
     CHECK(!gzip::is_compressed(pointer, data.size()));
-    
+
     int strategy;
 
     SECTION("strategy - invalid compression")
@@ -110,7 +114,7 @@ TEST_CASE("round trip compression - gzip")
         {
             int level = Z_NO_COMPRESSION;
             std::string compressed_data = gzip::compress(pointer, data.size(), level, strategy);
-            const char * compressed_pointer = compressed_data.data();
+            const char* compressed_pointer = compressed_data.data();
             CHECK(gzip::is_compressed(compressed_pointer, compressed_data.size()));
             std::string new_data = gzip::decompress(compressed_pointer, compressed_data.size());
             CHECK(data == new_data);
@@ -120,7 +124,7 @@ TEST_CASE("round trip compression - gzip")
         {
             int level = Z_DEFAULT_COMPRESSION;
             std::string compressed_data = gzip::compress(pointer, data.size(), level, strategy);
-            const char * compressed_pointer = compressed_data.data();
+            const char* compressed_pointer = compressed_data.data();
             CHECK(gzip::is_compressed(compressed_pointer, compressed_data.size()));
             std::string new_data = gzip::decompress(compressed_pointer, compressed_data.size());
             CHECK(data == new_data);
@@ -131,7 +135,7 @@ TEST_CASE("round trip compression - gzip")
             for (int level = Z_BEST_SPEED; level <= Z_BEST_COMPRESSION; ++level)
             {
                 std::string compressed_data = gzip::compress(pointer, data.size(), level, strategy);
-                const char * compressed_pointer = compressed_data.data();
+                const char* compressed_pointer = compressed_data.data();
                 CHECK(gzip::is_compressed(compressed_pointer, compressed_data.size()));
                 std::string new_data = gzip::decompress(compressed_pointer, compressed_data.size());
                 CHECK(data == new_data);
@@ -147,7 +151,7 @@ TEST_CASE("round trip compression - gzip")
         {
             int level = Z_NO_COMPRESSION;
             std::string compressed_data = gzip::compress(pointer, data.size(), level, strategy);
-            const char * compressed_pointer = compressed_data.data();
+            const char* compressed_pointer = compressed_data.data();
             CHECK(gzip::is_compressed(compressed_pointer, compressed_data.size()));
             std::string new_data = gzip::decompress(compressed_pointer, compressed_data.size());
             CHECK(data == new_data);
@@ -157,7 +161,7 @@ TEST_CASE("round trip compression - gzip")
         {
             int level = Z_DEFAULT_COMPRESSION;
             std::string compressed_data = gzip::compress(pointer, data.size(), level, strategy);
-            const char * compressed_pointer = compressed_data.data();
+            const char* compressed_pointer = compressed_data.data();
             CHECK(gzip::is_compressed(compressed_pointer, compressed_data.size()));
             std::string new_data = gzip::decompress(compressed_pointer, compressed_data.size());
             CHECK(data == new_data);
@@ -168,7 +172,7 @@ TEST_CASE("round trip compression - gzip")
             for (int level = Z_BEST_SPEED; level <= Z_BEST_COMPRESSION; ++level)
             {
                 std::string compressed_data = gzip::compress(pointer, data.size(), level, strategy);
-                const char * compressed_pointer = compressed_data.data();
+                const char* compressed_pointer = compressed_data.data();
                 CHECK(gzip::is_compressed(compressed_pointer, compressed_data.size()));
                 std::string new_data = gzip::decompress(compressed_pointer, compressed_data.size());
                 CHECK(data == new_data);
@@ -184,7 +188,7 @@ TEST_CASE("round trip compression - gzip")
         {
             int level = Z_NO_COMPRESSION;
             std::string compressed_data = gzip::compress(pointer, data.size(), level, strategy);
-            const char * compressed_pointer = compressed_data.data();
+            const char* compressed_pointer = compressed_data.data();
             CHECK(gzip::is_compressed(compressed_pointer, compressed_data.size()));
             std::string new_data = gzip::decompress(compressed_pointer, compressed_data.size());
             CHECK(data == new_data);
@@ -194,7 +198,7 @@ TEST_CASE("round trip compression - gzip")
         {
             int level = Z_DEFAULT_COMPRESSION;
             std::string compressed_data = gzip::compress(pointer, data.size(), level, strategy);
-            const char * compressed_pointer = compressed_data.data();
+            const char* compressed_pointer = compressed_data.data();
             CHECK(gzip::is_compressed(compressed_pointer, compressed_data.size()));
             std::string new_data = gzip::decompress(compressed_pointer, compressed_data.size());
             CHECK(data == new_data);
@@ -205,7 +209,7 @@ TEST_CASE("round trip compression - gzip")
             for (int level = Z_BEST_SPEED; level <= Z_BEST_COMPRESSION; ++level)
             {
                 std::string compressed_data = gzip::compress(pointer, data.size(), level, strategy);
-                const char * compressed_pointer = compressed_data.data();
+                const char* compressed_pointer = compressed_data.data();
                 CHECK(gzip::is_compressed(compressed_pointer, compressed_data.size()));
                 std::string new_data = gzip::decompress(compressed_pointer, compressed_data.size());
                 CHECK(data == new_data);
@@ -221,7 +225,7 @@ TEST_CASE("round trip compression - gzip")
         {
             int level = Z_NO_COMPRESSION;
             std::string compressed_data = gzip::compress(pointer, data.size(), level, strategy);
-            const char * compressed_pointer = compressed_data.data();
+            const char* compressed_pointer = compressed_data.data();
             CHECK(gzip::is_compressed(compressed_pointer, compressed_data.size()));
             std::string new_data = gzip::decompress(compressed_pointer, compressed_data.size());
             CHECK(data == new_data);
@@ -231,7 +235,7 @@ TEST_CASE("round trip compression - gzip")
         {
             int level = Z_DEFAULT_COMPRESSION;
             std::string compressed_data = gzip::compress(pointer, data.size(), level, strategy);
-            const char * compressed_pointer = compressed_data.data();
+            const char* compressed_pointer = compressed_data.data();
             CHECK(gzip::is_compressed(compressed_pointer, compressed_data.size()));
             std::string new_data = gzip::decompress(compressed_pointer, compressed_data.size());
             CHECK(data == new_data);
@@ -242,7 +246,7 @@ TEST_CASE("round trip compression - gzip")
             for (int level = Z_BEST_SPEED; level <= Z_BEST_COMPRESSION; ++level)
             {
                 std::string compressed_data = gzip::compress(pointer, data.size(), level, strategy);
-                const char * compressed_pointer = compressed_data.data();
+                const char* compressed_pointer = compressed_data.data();
                 CHECK(gzip::is_compressed(compressed_pointer, compressed_data.size()));
                 std::string new_data = gzip::decompress(compressed_pointer, compressed_data.size());
                 CHECK(data == new_data);
@@ -258,7 +262,7 @@ TEST_CASE("round trip compression - gzip")
         {
             int level = Z_NO_COMPRESSION;
             std::string compressed_data = gzip::compress(pointer, data.size(), level, strategy);
-            const char * compressed_pointer = compressed_data.data();
+            const char* compressed_pointer = compressed_data.data();
             CHECK(gzip::is_compressed(compressed_pointer, compressed_data.size()));
             std::string new_data = gzip::decompress(compressed_pointer, compressed_data.size());
             CHECK(data == new_data);
@@ -268,7 +272,7 @@ TEST_CASE("round trip compression - gzip")
         {
             int level = Z_DEFAULT_COMPRESSION;
             std::string compressed_data = gzip::compress(pointer, data.size(), level, strategy);
-            const char * compressed_pointer = compressed_data.data();
+            const char* compressed_pointer = compressed_data.data();
             CHECK(gzip::is_compressed(compressed_pointer, compressed_data.size()));
             std::string new_data = gzip::decompress(compressed_pointer, compressed_data.size());
             CHECK(data == new_data);
@@ -279,7 +283,7 @@ TEST_CASE("round trip compression - gzip")
             for (int level = Z_BEST_SPEED; level <= Z_BEST_COMPRESSION; ++level)
             {
                 std::string compressed_data = gzip::compress(pointer, data.size(), level, strategy);
-                const char * compressed_pointer = compressed_data.data();
+                const char* compressed_pointer = compressed_data.data();
                 CHECK(gzip::is_compressed(compressed_pointer, compressed_data.size()));
                 std::string new_data = gzip::decompress(compressed_pointer, compressed_data.size());
                 CHECK(data == new_data);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,7 +1,7 @@
 #include <gzip.hpp>
 
-#include <iostream>
 #include <cassert>
+#include <iostream>
 #define CATCH_CONFIG_MAIN
 #include <catch.hpp>
 #include <limits>
@@ -15,7 +15,7 @@ TEST_CASE("successful compress - pointer") {
     const char * pointer = data.data();
 
     std::string value = gzip::compress(pointer, data.size());
-    REQUIRE(value.size() > 0);
+    REQUIRE(!value.empty());
 }
 
 TEST_CASE("fail compress - throws max size limit") {
@@ -48,7 +48,7 @@ TEST_CASE("successful decompress - pointer") {
     const char * compressed_pointer = compressed_data.data();
 
     std::string value = gzip::decompress(compressed_pointer, data.size());
-    REQUIRE(data.compare(value) == 0);
+    REQUIRE(data == value);
 }
 
 #ifdef DEBUG
@@ -113,7 +113,7 @@ TEST_CASE("round trip compression - gzip")
             const char * compressed_pointer = compressed_data.data();
             CHECK(gzip::is_compressed(compressed_pointer, compressed_data.size()));
             std::string new_data = gzip::decompress(compressed_pointer, compressed_data.size());
-            CHECK(data.compare(new_data) == 0);
+            CHECK(data == new_data);
         }
 
         SECTION("default compression level")


### PR DESCRIPTION
Per https://github.com/mapbox/hpp-skel/pull/42, add and run clang-tidy.

cc @springmeyer 