### PR TITLE
Fix C++ style casts

### DIFF
--- a/include/gzip.hpp
+++ b/include/gzip.hpp
@@ -3,7 +3,8 @@
  * gzip implements a standard namespace with a few available functions.
  */
 
-#include "gzip/compress.hpp"
-#include "gzip/decompress.hpp"
-#include "gzip/utils.hpp"
-#include "gzip/version.hpp"
+#include <gzip/compress.hpp>
+#include <gzip/config.hpp>
+#include <gzip/decompress.hpp>
+#include <gzip/utils.hpp>
+#include <gzip/version.hpp>

--- a/include/gzip/compress.hpp
+++ b/include/gzip/compress.hpp
@@ -1,8 +1,10 @@
-#include <iostream>
+#include <gzip/config.hpp>
+
 // zlib
 #include <zlib.h>
 // std
 #include <limits>
+#include <string>
 #include <stdexcept>
 
 namespace gzip {
@@ -31,7 +33,7 @@ std::string compress(const char* data,
     {
         throw std::runtime_error("deflate init failed");
     }
-    deflate_s.next_in = (Bytef*)data;
+    deflate_s.next_in = reinterpret_cast<z_const Bytef*>(data);
 
 #ifdef DEBUG
     // Verify if size input will fit into unsigned int, type used for zlib's avail_in
@@ -57,7 +59,7 @@ std::string compress(const char* data,
         // There is no way we see that "increase" would not fit in an unsigned int,
         // hence we use static cast here to avoid -Wshorten-64-to-32 error
         deflate_s.avail_out = static_cast<unsigned int>(increase);
-        deflate_s.next_out = (Bytef*)(output.data() + length);
+        deflate_s.next_out = reinterpret_cast<Bytef*>((&output[0] + length));
         // From http://www.zlib.net/zlib_how.html
         // "deflate() has a return value that can indicate errors, yet we do not check it here.
         // Why not? Well, it turns out that deflate() can do no wrong here."

--- a/include/gzip/compress.hpp
+++ b/include/gzip/compress.hpp
@@ -4,8 +4,8 @@
 #include <zlib.h>
 // std
 #include <limits>
-#include <string>
 #include <stdexcept>
+#include <string>
 
 namespace gzip {
 

--- a/include/gzip/config.hpp
+++ b/include/gzip/config.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#ifndef ZLIB_CONST
+#define ZLIB_CONST
+#endif

--- a/include/gzip/decompress.hpp
+++ b/include/gzip/decompress.hpp
@@ -1,7 +1,10 @@
+#include <gzip/config.hpp>
+
 // zlib
 #include <zlib.h>
 // std
 #include <limits>
+#include <string>
 #include <stdexcept>
 
 namespace gzip {
@@ -25,7 +28,7 @@ std::string decompress(const char* data, std::size_t size)
     {
         throw std::runtime_error("inflate init failed");
     }
-    inflate_s.next_in = (Bytef*)data;
+    inflate_s.next_in = reinterpret_cast<z_const Bytef*>(data);
 
 #ifdef DEBUG
     // Verify if size (long type) input will fit into unsigned int, type used for zlib's avail_in
@@ -47,7 +50,7 @@ std::string decompress(const char* data, std::size_t size)
     {
         output.resize(length + 2 * size);
         inflate_s.avail_out = static_cast<unsigned int>(2 * size);
-        inflate_s.next_out = (Bytef*)(output.data() + length);
+        inflate_s.next_out = reinterpret_cast<Bytef*>(&output[0] + length);
         int ret = inflate(&inflate_s, Z_FINISH);
         if (ret != Z_STREAM_END && ret != Z_OK && ret != Z_BUF_ERROR)
         {

--- a/include/gzip/decompress.hpp
+++ b/include/gzip/decompress.hpp
@@ -4,8 +4,8 @@
 #include <zlib.h>
 // std
 #include <limits>
-#include <string>
 #include <stdexcept>
+#include <string>
 
 namespace gzip {
 

--- a/include/gzip/utils.hpp
+++ b/include/gzip/utils.hpp
@@ -1,4 +1,7 @@
+#include <cstdlib>
+
 namespace gzip {
+
 // These live in gzip.hpp because it doesnt need to use deps.
 // Otherwise, they would need to live in impl files if these methods used
 // zlib structures or functions like inflate/deflate)


### PR DESCRIPTION
Fixes the compiler warnings/errors that arose from #18 

## Context

We should be using C++ style casts instead of C style casts. While C style casts allow for multiple types of casting to happen in one, C++ style casts require you to be explicit.

Previous to this PR we were casing a `const char *` into a `unsigned char`. So both a reinterpret cast (to go from `char` to `unsigned char` is needed) and a `const_cast` to drop the `const`.

After studying the code I realized we don't want to do the `const_cast` - we'd be removing the `const` from data that truly is const and should not be modified, which is bad practice.

Then I noticed that zlib has a `ZLIB_CONST` define that can be turned on to allow for const data to be passed in. This is ideal so that we don't need to cast it away.

I noticed it can be enabled here: https://github.com/madler/zlib/blob/cacf7f1d4e3d44d871b605da3b647f07d718623f/zconf.h#L234

Which makes the `z_const` define non-blank. So, this PR moves to C++ style casts and avoids the need for a const cast.

It looks like this will mean that the minimum zlib version we can support will now be zlib 1.2.5.2 per https://github.com/nodejs/node/issues/9110. I think this is fine.

Refs mapbox/cpp#37