### PR TITLE
Libdeflate port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,8 @@ include_directories(SYSTEM ${MASON_PACKAGE_catch_INCLUDE_DIRS})
 mason_use(benchmark VERSION 1.3.0)
 include_directories(SYSTEM ${MASON_PACKAGE_benchmark_INCLUDE_DIRS})
 
-mason_use(zlib VERSION 1.2.8)
-include_directories(SYSTEM ${MASON_PACKAGE_zlib_INCLUDE_DIRS})
+mason_use(libdeflate VERSION e9d1014)
+include_directories(SYSTEM ${MASON_PACKAGE_libdeflate_INCLUDE_DIRS})
 
 include_directories("${PROJECT_SOURCE_DIR}/include")
 
@@ -49,5 +49,5 @@ file(GLOB BENCH_SOURCES bench/*.cpp)
 add_executable(bench-tests ${BENCH_SOURCES})
 
 # link zlib static library to the unit-tests binary so the tests know where to find the zlib impl code
-target_link_libraries(unit-tests ${MASON_PACKAGE_zlib_STATIC_LIBS})
-target_link_libraries(bench-tests ${MASON_PACKAGE_benchmark_STATIC_LIBS} ${CMAKE_THREAD_LIBS_INIT} ${MASON_PACKAGE_zlib_STATIC_LIBS})
+target_link_libraries(unit-tests ${MASON_PACKAGE_libdeflate_STATIC_LIBS})
+target_link_libraries(bench-tests ${MASON_PACKAGE_benchmark_STATIC_LIBS} ${CMAKE_THREAD_LIBS_INIT} ${MASON_PACKAGE_libdeflate_STATIC_LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ include_directories(SYSTEM ${MASON_PACKAGE_catch_INCLUDE_DIRS})
 mason_use(benchmark VERSION 1.3.0)
 include_directories(SYSTEM ${MASON_PACKAGE_benchmark_INCLUDE_DIRS})
 
-mason_use(libdeflate VERSION e9d1014)
+mason_use(libdeflate VERSION 1.0)
 include_directories(SYSTEM ${MASON_PACKAGE_libdeflate_INCLUDE_DIRS})
 
 include_directories("${PROJECT_SOURCE_DIR}/include")

--- a/include/gzip/compress.hpp
+++ b/include/gzip/compress.hpp
@@ -37,9 +37,9 @@ class Compressor
         }
     }
 
-    template <typename InputType>
-    void compress(InputType& output,
-                  const char* data,
+    template <typename OutputType>
+    void compress(OutputType& output,
+                  char const* data,
                   std::size_t size) const
     {
 

--- a/include/gzip/compress.hpp
+++ b/include/gzip/compress.hpp
@@ -15,6 +15,9 @@ class Compressor
     std::size_t max_;
     int level_;
     struct libdeflate_compressor* compressor_ = nullptr;
+    // make noncopyable
+    Compressor(Compressor const&) = delete;
+    Compressor& operator=(Compressor const&) = delete;
 
   public:
     Compressor(int level = 6,

--- a/include/gzip/compress.hpp
+++ b/include/gzip/compress.hpp
@@ -42,14 +42,6 @@ class Compressor
                   char const* data,
                   std::size_t size) const
     {
-
-#ifdef DEBUG
-        // Verify if size input will fit into unsigned int, type used for zlib's avail_in
-        if (size > std::numeric_limits<unsigned int>::max())
-        {
-            throw std::runtime_error("size arg is too large to fit into unsigned int type");
-        }
-#endif
         if (size > max_)
         {
             throw std::runtime_error("size may use more memory than intended when decompressing");

--- a/include/gzip/compress.hpp
+++ b/include/gzip/compress.hpp
@@ -1,7 +1,7 @@
 #include <gzip/config.hpp>
 
 // zlib
-#include <zlib.h>
+#include <libdeflate.h>
 
 // std
 #include <limits>
@@ -14,13 +14,26 @@ class Compressor
 {
     std::size_t max_;
     int level_;
+    struct libdeflate_compressor * compressor_ = nullptr;
 
   public:
-    Compressor(int level = Z_DEFAULT_COMPRESSION,
+    Compressor(int level = 6,
                std::size_t max_bytes = 2000000000) // by default refuse operation if uncompressed data is > 2GB
         : max_(max_bytes),
           level_(level)
     {
+        compressor_ = libdeflate_alloc_compressor(level_);
+        if (!compressor_) {
+            throw std::runtime_error("libdeflate_alloc_compressor failed");
+        }
+    }
+
+    ~Compressor()
+    {
+        if (compressor_)
+        {
+            libdeflate_free_compressor(compressor_);
+        }
     }
 
     template <typename InputType>
@@ -41,68 +54,27 @@ class Compressor
             throw std::runtime_error("size may use more memory than intended when decompressing");
         }
 
-        z_stream deflate_s;
-        deflate_s.zalloc = Z_NULL;
-        deflate_s.zfree = Z_NULL;
-        deflate_s.opaque = Z_NULL;
-        deflate_s.avail_in = 0;
-        deflate_s.next_in = Z_NULL;
-
-        // The windowBits parameter is the base two logarithm of the window size (the size of the history buffer).
-        // It should be in the range 8..15 for this version of the library.
-        // Larger values of this parameter result in better compression at the expense of memory usage.
-        // This range of values also changes the decoding type:
-        //  -8 to -15 for raw deflate
-        //  8 to 15 for zlib
-        // (8 to 15) + 16 for gzip
-        // (8 to 15) + 32 to automatically detect gzip/zlib header (decompression/inflate only)
-        constexpr int window_bits = 15 + 16; // gzip with windowbits of 15
-
-        constexpr int mem_level = 8;
-        // The memory requirements for deflate are (in bytes):
-        // (1 << (window_bits+2)) +  (1 << (mem_level+9))
-        // with a default value of 8 for mem_level and our window_bits of 15
-        // this is 128Kb
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-        if (deflateInit2(&deflate_s, level_, Z_DEFLATED, window_bits, mem_level, Z_DEFAULT_STRATEGY) != Z_OK)
-        {
-            throw std::runtime_error("deflate init failed");
+        std::size_t max_compressed_size = libdeflate_gzip_compress_bound(compressor_,size);
+        // TODO: sanity check this before allocating
+        if (max_compressed_size > output.size()) {
+            output.resize(max_compressed_size);
         }
-#pragma GCC diagnostic pop
 
-        deflate_s.next_in = reinterpret_cast<z_const Bytef*>(data);
-        deflate_s.avail_in = static_cast<unsigned int>(size);
-
-        std::size_t size_compressed = 0;
-        do
-        {
-            size_t increase = size / 2 + 1024;
-            if (output.size() < (size_compressed + increase))
-            {
-                output.resize(size_compressed + increase);
-            }
-            // There is no way we see that "increase" would not fit in an unsigned int,
-            // hence we use static cast here to avoid -Wshorten-64-to-32 error
-            deflate_s.avail_out = static_cast<unsigned int>(increase);
-            deflate_s.next_out = reinterpret_cast<Bytef*>((&output[0] + size_compressed));
-            // From http://www.zlib.net/zlib_how.html
-            // "deflate() has a return value that can indicate errors, yet we do not check it here.
-            // Why not? Well, it turns out that deflate() can do no wrong here."
-            // Basically only possible error is from deflateInit not working properly
-            deflate(&deflate_s, Z_FINISH);
-            size_compressed += (increase - deflate_s.avail_out);
-        } while (deflate_s.avail_out == 0);
-
-        deflateEnd(&deflate_s);
-        output.resize(size_compressed);
+        std::size_t actual_compressed_size = libdeflate_gzip_compress(compressor_,
+                                                  data,
+                                                  size,
+                                                  reinterpret_cast<void*>(&output[0]),
+                                                  max_compressed_size);
+        if (actual_compressed_size == 0) {
+            throw std::runtime_error("actual_compressed_size 0");
+        }
+        output.resize(actual_compressed_size);
     }
 };
 
 inline std::string compress(const char* data,
                             std::size_t size,
-                            int level = Z_DEFAULT_COMPRESSION)
+                            int level = 6)
 {
     Compressor comp(level);
     std::string output;

--- a/include/gzip/compress.hpp
+++ b/include/gzip/compress.hpp
@@ -14,7 +14,7 @@ class Compressor
 {
     std::size_t max_;
     int level_;
-    struct libdeflate_compressor * compressor_ = nullptr;
+    struct libdeflate_compressor* compressor_ = nullptr;
 
   public:
     Compressor(int level = 6,
@@ -23,7 +23,8 @@ class Compressor
           level_(level)
     {
         compressor_ = libdeflate_alloc_compressor(level_);
-        if (!compressor_) {
+        if (!compressor_)
+        {
             throw std::runtime_error("libdeflate_alloc_compressor failed");
         }
     }
@@ -54,18 +55,20 @@ class Compressor
             throw std::runtime_error("size may use more memory than intended when decompressing");
         }
 
-        std::size_t max_compressed_size = libdeflate_gzip_compress_bound(compressor_,size);
+        std::size_t max_compressed_size = libdeflate_gzip_compress_bound(compressor_, size);
         // TODO: sanity check this before allocating
-        if (max_compressed_size > output.size()) {
+        if (max_compressed_size > output.size())
+        {
             output.resize(max_compressed_size);
         }
 
         std::size_t actual_compressed_size = libdeflate_gzip_compress(compressor_,
-                                                  data,
-                                                  size,
-                                                  reinterpret_cast<void*>(&output[0]),
-                                                  max_compressed_size);
-        if (actual_compressed_size == 0) {
+                                                                      data,
+                                                                      size,
+                                                                      reinterpret_cast<void*>(&output[0]),
+                                                                      max_compressed_size);
+        if (actual_compressed_size == 0)
+        {
             throw std::runtime_error("actual_compressed_size 0");
         }
         output.resize(actual_compressed_size);

--- a/include/gzip/compress.hpp
+++ b/include/gzip/compress.hpp
@@ -65,7 +65,7 @@ class Compressor
         std::size_t actual_compressed_size = libdeflate_gzip_compress(compressor_,
                                                                       data,
                                                                       size,
-                                                                      reinterpret_cast<void*>(&output[0]),
+                                                                      const_cast<char*>(output.data()),
                                                                       max_compressed_size);
         if (actual_compressed_size == 0)
         {

--- a/include/gzip/decompress.hpp
+++ b/include/gzip/decompress.hpp
@@ -56,7 +56,7 @@ class Decompressor
         // https://github.com/kaorimatz/libdeflate-ruby/blob/0e33da96cdaad3162f03ec924b25b2f4f2847538/ext/libdeflate/libdeflate_ext.c#L340
         // https://github.com/ebiggers/libdeflate/commit/5a9d25a8922e2d74618fba96e56db4fe145510f4
         std::size_t actual_size;
-        std::size_t uncompressed_size_guess = size * 3;
+        std::size_t uncompressed_size_guess = size * 4;
         output.resize(uncompressed_size_guess);
         enum libdeflate_result result = libdeflate_gzip_decompress(decompressor_,
                                                                    data,

--- a/include/gzip/decompress.hpp
+++ b/include/gzip/decompress.hpp
@@ -56,11 +56,11 @@ class Decompressor
             {
                 break;
             }
-            std::size_t new_size = (output.capacity() << 1) - output.size();
-            if (new_size > max_)
+            if (output.size() == max_)
             {
-                throw std::runtime_error("request to resize output buffer exceeded maximum limit");
+                throw std::runtime_error("request to resize output buffer can't exceed maximum limit");
             }
+            std::size_t new_size = std::min((output.capacity() << 1) - output.size(), max_);
             output.resize(new_size);
         }
 

--- a/include/gzip/decompress.hpp
+++ b/include/gzip/decompress.hpp
@@ -56,7 +56,7 @@ class Decompressor
         // https://github.com/kaorimatz/libdeflate-ruby/blob/0e33da96cdaad3162f03ec924b25b2f4f2847538/ext/libdeflate/libdeflate_ext.c#L340
         // https://github.com/ebiggers/libdeflate/commit/5a9d25a8922e2d74618fba96e56db4fe145510f4
         std::size_t actual_size;
-        std::size_t uncompressed_size_guess = size * 2;
+        std::size_t uncompressed_size_guess = size * 3;
         output.resize(uncompressed_size_guess);
         enum libdeflate_result result = libdeflate_gzip_decompress(decompressor_,
                                                                    data,

--- a/include/gzip/decompress.hpp
+++ b/include/gzip/decompress.hpp
@@ -14,6 +14,9 @@ class Decompressor
 {
     std::size_t const max_;
     struct libdeflate_decompressor* decompressor_ = nullptr;
+    // make noncopyable
+    Decompressor(Decompressor const&) = delete;
+    Decompressor& operator=(Decompressor const&) = delete;
 
   public:
     Decompressor(std::size_t max_bytes = 2147483648u) // by default refuse operation if required uutput buffer is > 2GB

--- a/include/gzip/decompress.hpp
+++ b/include/gzip/decompress.hpp
@@ -1,7 +1,7 @@
 #include <gzip/config.hpp>
 
 // zlib
-#include <zlib.h>
+#include <libdeflate.h>
 
 // std
 #include <limits>
@@ -13,84 +13,68 @@ namespace gzip {
 class Decompressor
 {
     std::size_t max_;
+    struct libdeflate_decompressor * decompressor_ = nullptr;
 
   public:
     Decompressor(std::size_t max_bytes = 1000000000) // by default refuse operation if compressed data is > 1GB
         : max_(max_bytes)
-    {
+     {
+        decompressor_ = libdeflate_alloc_decompressor();
+        if (!decompressor_) {
+            throw std::runtime_error("libdeflate_alloc_decompressor failed");
+        }
     }
+
+    ~Decompressor()
+    {
+       if (decompressor_)
+       {
+           libdeflate_free_decompressor(decompressor_);
+       }
+     }
 
     template <typename OutputType>
     void decompress(OutputType& output,
                     const char* data,
                     std::size_t size) const
     {
-        z_stream inflate_s;
-
-        inflate_s.zalloc = Z_NULL;
-        inflate_s.zfree = Z_NULL;
-        inflate_s.opaque = Z_NULL;
-        inflate_s.avail_in = 0;
-        inflate_s.next_in = Z_NULL;
-
-        // The windowBits parameter is the base two logarithm of the window size (the size of the history buffer).
-        // It should be in the range 8..15 for this version of the library.
-        // Larger values of this parameter result in better compression at the expense of memory usage.
-        // This range of values also changes the decoding type:
-        //  -8 to -15 for raw deflate
-        //  8 to 15 for zlib
-        // (8 to 15) + 16 for gzip
-        // (8 to 15) + 32 to automatically detect gzip/zlib header
-        constexpr int window_bits = 15 + 32; // auto with windowbits of 15
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-        if (inflateInit2(&inflate_s, window_bits) != Z_OK)
-        {
-            throw std::runtime_error("inflate init failed");
-        }
-#pragma GCC diagnostic pop
-        inflate_s.next_in = reinterpret_cast<z_const Bytef*>(data);
 
 #ifdef DEBUG
         // Verify if size (long type) input will fit into unsigned int, type used for zlib's avail_in
         std::uint64_t size_64 = size * 2;
         if (size_64 > std::numeric_limits<unsigned int>::max())
         {
-            inflateEnd(&inflate_s);
             throw std::runtime_error("size arg is too large to fit into unsigned int type x2");
         }
 #endif
         if (size > max_ || (size * 2) > max_)
         {
-            inflateEnd(&inflate_s);
             throw std::runtime_error("size may use more memory than intended when decompressing");
         }
-        inflate_s.avail_in = static_cast<unsigned int>(size);
-        std::size_t size_uncompressed = 0;
-        do
-        {
-            std::size_t resize_to = size_uncompressed + 2 * size;
-            if (resize_to > max_)
-            {
-                inflateEnd(&inflate_s);
-                throw std::runtime_error("size of output string will use more memory then intended when decompressing");
-            }
-            output.resize(resize_to);
-            inflate_s.avail_out = static_cast<unsigned int>(2 * size);
-            inflate_s.next_out = reinterpret_cast<Bytef*>(&output[0] + size_uncompressed);
-            int ret = inflate(&inflate_s, Z_FINISH);
-            if (ret != Z_STREAM_END && ret != Z_OK && ret != Z_BUF_ERROR)
-            {
-                std::string error_msg = inflate_s.msg;
-                inflateEnd(&inflate_s);
-                throw std::runtime_error(error_msg);
-            }
 
-            size_uncompressed += (2 * size - inflate_s.avail_out);
-        } while (inflate_s.avail_out == 0);
-        inflateEnd(&inflate_s);
-        output.resize(size_uncompressed);
+        // https://github.com/kaorimatz/libdeflate-ruby/blob/0e33da96cdaad3162f03ec924b25b2f4f2847538/ext/libdeflate/libdeflate_ext.c#L340
+        // https://github.com/ebiggers/libdeflate/commit/5a9d25a8922e2d74618fba96e56db4fe145510f4
+        std::size_t actual_size;
+        std::size_t uncompressed_size_guess = size * 2;
+        output.resize(uncompressed_size_guess);
+        enum libdeflate_result result = libdeflate_gzip_decompress(decompressor_,
+                                            data,
+                                            size,
+                                            static_cast<void*>(&output[0]),
+                                            uncompressed_size_guess, &actual_size);
+        if (result == LIBDEFLATE_INSUFFICIENT_SPACE) {
+            throw std::runtime_error("no space: did not succeed");
+        }
+        else if (result == LIBDEFLATE_SHORT_OUTPUT) {
+            throw std::runtime_error("short output: did not succeed");
+        }
+        else if (result == LIBDEFLATE_BAD_DATA) {
+            throw std::runtime_error("bad data: did not succeed");
+        }
+        else if (result != LIBDEFLATE_SUCCESS) {
+            throw std::runtime_error("did not succeed");
+        }
+        output.resize(actual_size);
     }
 };
 

--- a/include/gzip/decompress.hpp
+++ b/include/gzip/decompress.hpp
@@ -13,25 +13,26 @@ namespace gzip {
 class Decompressor
 {
     std::size_t max_;
-    struct libdeflate_decompressor * decompressor_ = nullptr;
+    struct libdeflate_decompressor* decompressor_ = nullptr;
 
   public:
     Decompressor(std::size_t max_bytes = 1000000000) // by default refuse operation if compressed data is > 1GB
         : max_(max_bytes)
-     {
+    {
         decompressor_ = libdeflate_alloc_decompressor();
-        if (!decompressor_) {
+        if (!decompressor_)
+        {
             throw std::runtime_error("libdeflate_alloc_decompressor failed");
         }
     }
 
     ~Decompressor()
     {
-       if (decompressor_)
-       {
-           libdeflate_free_decompressor(decompressor_);
-       }
-     }
+        if (decompressor_)
+        {
+            libdeflate_free_decompressor(decompressor_);
+        }
+    }
 
     template <typename OutputType>
     void decompress(OutputType& output,
@@ -58,20 +59,24 @@ class Decompressor
         std::size_t uncompressed_size_guess = size * 2;
         output.resize(uncompressed_size_guess);
         enum libdeflate_result result = libdeflate_gzip_decompress(decompressor_,
-                                            data,
-                                            size,
-                                            static_cast<void*>(&output[0]),
-                                            uncompressed_size_guess, &actual_size);
-        if (result == LIBDEFLATE_INSUFFICIENT_SPACE) {
+                                                                   data,
+                                                                   size,
+                                                                   static_cast<void*>(&output[0]),
+                                                                   uncompressed_size_guess, &actual_size);
+        if (result == LIBDEFLATE_INSUFFICIENT_SPACE)
+        {
             throw std::runtime_error("no space: did not succeed");
         }
-        else if (result == LIBDEFLATE_SHORT_OUTPUT) {
+        else if (result == LIBDEFLATE_SHORT_OUTPUT)
+        {
             throw std::runtime_error("short output: did not succeed");
         }
-        else if (result == LIBDEFLATE_BAD_DATA) {
+        else if (result == LIBDEFLATE_BAD_DATA)
+        {
             throw std::runtime_error("bad data: did not succeed");
         }
-        else if (result != LIBDEFLATE_SUCCESS) {
+        else if (result != LIBDEFLATE_SUCCESS)
+        {
             throw std::runtime_error("did not succeed");
         }
         output.resize(actual_size);

--- a/include/gzip/utils.hpp
+++ b/include/gzip/utils.hpp
@@ -8,15 +8,15 @@ namespace gzip {
 inline bool is_compressed(const char* data, std::size_t size) noexcept
 {
     return size > 2 &&
-        (
-            // zlib
-            (
-                static_cast<uint8_t>(data[0]) == 0x78 &&
-                (static_cast<uint8_t>(data[1]) == 0x9C ||
-                 static_cast<uint8_t>(data[1]) == 0x01 ||
-                 static_cast<uint8_t>(data[1]) == 0xDA ||
-                 static_cast<uint8_t>(data[1]) == 0x5E)) ||
-            // gzip
-            (static_cast<uint8_t>(data[0]) == 0x1F && static_cast<uint8_t>(data[1]) == 0x8B));
+           (
+               // zlib
+               (
+                   static_cast<uint8_t>(data[0]) == 0x78 &&
+                   (static_cast<uint8_t>(data[1]) == 0x9C ||
+                    static_cast<uint8_t>(data[1]) == 0x01 ||
+                    static_cast<uint8_t>(data[1]) == 0xDA ||
+                    static_cast<uint8_t>(data[1]) == 0x5E)) ||
+               // gzip
+               (static_cast<uint8_t>(data[0]) == 0x1F && static_cast<uint8_t>(data[1]) == 0x8B));
 }
 } // namespace gzip

--- a/include/gzip/utils.hpp
+++ b/include/gzip/utils.hpp
@@ -5,18 +5,18 @@ namespace gzip {
 // These live in gzip.hpp because it doesnt need to use deps.
 // Otherwise, they would need to live in impl files if these methods used
 // zlib structures or functions like inflate/deflate)
-inline bool is_compressed(const char* data, std::size_t size)
+inline bool is_compressed(const char* data, std::size_t size) noexcept
 {
     return size > 2 &&
-           (
-               // zlib
-               (
-                   static_cast<uint8_t>(data[0]) == 0x78 &&
-                   (static_cast<uint8_t>(data[1]) == 0x9C ||
-                    static_cast<uint8_t>(data[1]) == 0x01 ||
-                    static_cast<uint8_t>(data[1]) == 0xDA ||
-                    static_cast<uint8_t>(data[1]) == 0x5E)) ||
-               // gzip
-               (static_cast<uint8_t>(data[0]) == 0x1F && static_cast<uint8_t>(data[1]) == 0x8B));
+        (
+            // zlib
+            (
+                static_cast<uint8_t>(data[0]) == 0x78 &&
+                (static_cast<uint8_t>(data[1]) == 0x9C ||
+                 static_cast<uint8_t>(data[1]) == 0x01 ||
+                 static_cast<uint8_t>(data[1]) == 0xDA ||
+                 static_cast<uint8_t>(data[1]) == 0x5E)) ||
+            // gzip
+            (static_cast<uint8_t>(data[0]) == 0x1F && static_cast<uint8_t>(data[1]) == 0x8B));
 }
 } // namespace gzip

--- a/test/test_io.cpp
+++ b/test/test_io.cpp
@@ -49,23 +49,6 @@ TEST_CASE("successful decompress - pointer")
     REQUIRE(data == value);
 }
 
-#ifdef DEBUG
-TEST_CASE("fail decompress - pointer, debug throws int overflow")
-{
-    std::string data = "hello hello hello hello";
-    const char* pointer = data.data();
-    std::string compressed_data = gzip::compress(pointer, data.size());
-    const char* compressed_pointer = compressed_data.data();
-
-    // numeric_limit useful for integer conversion
-    unsigned int i = std::numeric_limits<unsigned int>::max();
-    // turn int i into a long, so we can add to it safely without overflow
-    unsigned long l = static_cast<unsigned long>(i) + 1;
-
-    CHECK_THROWS_WITH(gzip::decompress(compressed_pointer, l), Catch::Contains("size arg is too large to fit into unsigned int type x2"));
-}
-#endif
-
 TEST_CASE("invalid decompression")
 {
     std::string data("this is a string that should be compressed data");

--- a/test/test_io.cpp
+++ b/test/test_io.cpp
@@ -6,13 +6,9 @@
 TEST_CASE("successful compress")
 {
     std::string data = "hello hello hello hello";
-
-    SECTION("pointer")
-    {
-        const char* pointer = data.data();
-        std::string value = gzip::compress(pointer, data.size());
-        REQUIRE(!value.empty());
-    }
+    const char* pointer = data.data();
+    std::string value = gzip::compress(pointer, data.size());
+    REQUIRE(!value.empty());
 }
 
 TEST_CASE("fail compress - throws max size limit")

--- a/test/test_io.cpp
+++ b/test/test_io.cpp
@@ -25,20 +25,6 @@ TEST_CASE("fail compress - throws max size limit")
     CHECK_THROWS_WITH(gzip::compress(pointer, l), Catch::Contains("size may use more memory than intended when decompressing"));
 }
 
-#ifdef DEBUG
-TEST_CASE("fail compress - pointer, debug throws int overflow")
-{
-    std::string data = "hello hello hello hello";
-    const char* pointer = data.data();
-    // numeric_limit useful for integer conversion
-    unsigned int i = std::numeric_limits<unsigned int>::max();
-    // turn int i into a long, so we can add to it safely without overflow
-    unsigned long l = static_cast<unsigned long>(i) + 1;
-
-    CHECK_THROWS_WITH(gzip::compress(pointer, l), Catch::Contains("size arg is too large to fit into unsigned int type"));
-}
-#endif
-
 TEST_CASE("successful decompress - pointer")
 {
     std::string data = "hello hello hello hello";

--- a/test/test_io.cpp
+++ b/test/test_io.cpp
@@ -135,5 +135,5 @@ TEST_CASE("test decompression size limit")
     gzip::Decompressor decomp(limit);
     std::string output;
     CHECK_THROWS(decomp.decompress(output, str_compressed.data(), str_compressed.size()));
-    CHECK(output.size() < limit);
+    CHECK(output.size() <= limit);
 }

--- a/test/test_io.cpp
+++ b/test/test_io.cpp
@@ -90,7 +90,7 @@ TEST_CASE("round trip compression - gzip")
 
     SECTION("no compression")
     {
-        int level = Z_NO_COMPRESSION;
+        int level = 0;
         std::string compressed_data = gzip::compress(data.data(), data.size());
         CHECK(gzip::is_compressed(compressed_data.data(), compressed_data.size()));
         std::string new_data = gzip::decompress(compressed_data.data(), compressed_data.size());
@@ -99,7 +99,7 @@ TEST_CASE("round trip compression - gzip")
 
     SECTION("default compression level")
     {
-        int level = Z_DEFAULT_COMPRESSION;
+        int level = 6;
         std::string compressed_data = gzip::compress(data.data(), data.size());
         CHECK(gzip::is_compressed(compressed_data.data(), compressed_data.size()));
         std::string new_data = gzip::decompress(compressed_data.data(), compressed_data.size());
@@ -108,7 +108,7 @@ TEST_CASE("round trip compression - gzip")
 
     SECTION("compression level -- min to max")
     {
-        for (int level = Z_BEST_SPEED; level <= Z_BEST_COMPRESSION; ++level)
+        for (int level = 1; level <= 9; ++level)
         {
             std::string compressed_data = gzip::compress(data.data(), data.size());
             CHECK(gzip::is_compressed(compressed_data.data(), compressed_data.size()));

--- a/test/test_io.cpp
+++ b/test/test_io.cpp
@@ -130,7 +130,7 @@ TEST_CASE("test decompression size limit")
                                std::istreambuf_iterator<char>());
     stream.close();
 
-    std::size_t limit = 20 * 1024 * 1024; // 20 Mb
+    std::size_t limit = 500 * 1024 * 1024; // 500 Mb
     // file should be about 500 mb uncompressed
     gzip::Decompressor decomp(limit);
     std::string output;


### PR DESCRIPTION
This ports gzip-hpp to use libdeflate. This is for ~~experimental purposes only~~ testing in production and to investigate the potential speed improvements in using libdeflate.

If this proves viable (fast and robust), this is exciting because:

 - currently node.js statically links zlib
 - this forces all node c++ addons (that get dynamically loaded into node) to use ABI compatible zlib (otherwise weird things can happen like https://github.com/mapbox/node-zipfile/issues/63)
 - because libdeflate is a totally different API, if we use it, we could drop using zlib and then the problem of having node.js force a specific zlib version on us goes away!

Anyway, here are the first, promising, numbers locally:

Locally I see (with this PR) (smaller numbers is faster):

```
Run on (4 X 3500 MHz CPU s)
2018-04-03 15:43:13
----------------------------------------------------------------------------
Benchmark                                     Time           CPU Iterations
----------------------------------------------------------------------------
BM_compress                             1128545 ns    1118127 ns        661
BM_decompress                            202429 ns     201630 ns       3209
BM_compress_class                        778036 ns     777355 ns        979
BM_compress_class_no_reallocations       755331 ns     754569 ns        932
BM_decompress_class                      173623 ns     173489 ns       4284
BM_decompress_class_no_reallocations     162725 ns     162567 ns       4446
```

And with master:

```
Run on (4 X 3500 MHz CPU s)
2018-04-03 15:43:52
----------------------------------------------------------------------------
Benchmark                                     Time           CPU Iterations
----------------------------------------------------------------------------
BM_compress                             2124502 ns    2109067 ns        326
BM_decompress                            321913 ns     317480 ns       2122
BM_compress_class                       2181514 ns    2148765 ns        340
BM_compress_class_no_reallocations      2115537 ns    2102435 ns        329
BM_decompress_class                      317198 ns     315435 ns       2180
BM_decompress_class_no_reallocations     327788 ns     326020 ns       2243
```

TODO:
  - [x] Find a better way than `std::size_t uncompressed_size_guess = size * 3;` to figure out the uncompressed size to allocate.
  - [ ] Is the same level of compression being used with libdeflate?
  - [ ] Is `Z_DEFAULT_COMPRESSION` producing roughly the same sizes?
  - [ ] Do the speed differences seen locally between zlib and libdeflate persist in production systems?