### PR TITLE
Added missing include guards. Fixes a lot of compile issues.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,22 +28,22 @@ if (WERROR)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
 endif()
 
-# mason_use is a mason function within the mason.cmake file and provides ready-to-go vars, like "STATIC_LIBS" and "INCLUDE_DIRS"
-mason_use(catch VERSION 1.9.6 HEADER_ONLY)
-include_directories(SYSTEM ${MASON_PACKAGE_catch_INCLUDE_DIRS})
-
-mason_use(benchmark VERSION 1.3.0)
-include_directories(SYSTEM ${MASON_PACKAGE_benchmark_INCLUDE_DIRS})
-
-mason_use(zlib VERSION 1.2.8)
-include_directories(SYSTEM ${MASON_PACKAGE_zlib_INCLUDE_DIRS})
-
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 if (gzip_BUILD_TESTS)
+    # mason_use is a mason function within the mason.cmake file and provides ready-to-go vars, like "STATIC_LIBS" and "INCLUDE_DIRS"
+    mason_use(catch VERSION 1.9.6 HEADER_ONLY)
+    include_directories(SYSTEM ${MASON_PACKAGE_catch_INCLUDE_DIRS})
+
+    mason_use(benchmark VERSION 1.3.0)
+    include_directories(SYSTEM ${MASON_PACKAGE_benchmark_INCLUDE_DIRS})
+
+    mason_use(zlib VERSION 1.2.8)
+    include_directories(SYSTEM ${MASON_PACKAGE_zlib_INCLUDE_DIRS})
+
     file(GLOB TEST_SOURCES test/*.cpp)
     add_executable(unit-tests ${TEST_SOURCES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(hpp_skel LANGUAGES CXX)
+project(gzip-hpp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -38,16 +38,21 @@ include_directories(SYSTEM ${MASON_PACKAGE_benchmark_INCLUDE_DIRS})
 mason_use(zlib VERSION 1.2.8)
 include_directories(SYSTEM ${MASON_PACKAGE_zlib_INCLUDE_DIRS})
 
-include_directories("${PROJECT_SOURCE_DIR}/include")
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-file(GLOB TEST_SOURCES test/*.cpp)
-add_executable(unit-tests ${TEST_SOURCES})
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-# libbenchmark.a supports threads and therefore needs pthread support
-find_package(Threads REQUIRED)
-file(GLOB BENCH_SOURCES bench/*.cpp)
-add_executable(bench-tests ${BENCH_SOURCES})
+if (gzip_BUILD_TESTS)
+    file(GLOB TEST_SOURCES test/*.cpp)
+    add_executable(unit-tests ${TEST_SOURCES})
 
-# link zlib static library to the unit-tests binary so the tests know where to find the zlib impl code
-target_link_libraries(unit-tests ${MASON_PACKAGE_zlib_STATIC_LIBS})
-target_link_libraries(bench-tests ${MASON_PACKAGE_benchmark_STATIC_LIBS} ${CMAKE_THREAD_LIBS_INIT} ${MASON_PACKAGE_zlib_STATIC_LIBS})
+    # libbenchmark.a supports threads and therefore needs pthread support
+    find_package(Threads REQUIRED)
+    file(GLOB BENCH_SOURCES bench/*.cpp)
+    add_executable(bench-tests ${BENCH_SOURCES})
+
+    # link zlib static library to the unit-tests binary so the tests know where to find the zlib impl code
+    target_link_libraries(unit-tests ${MASON_PACKAGE_zlib_STATIC_LIBS})
+    target_link_libraries(bench-tests ${MASON_PACKAGE_benchmark_STATIC_LIBS} ${CMAKE_THREAD_LIBS_INIT} ${MASON_PACKAGE_zlib_STATIC_LIBS})
+endif()

--- a/include/gzip/compress.hpp
+++ b/include/gzip/compress.hpp
@@ -1,3 +1,7 @@
+#ifndef GZIP_HPP_INCLUDE_GZIP_COMPRESS_HPP
+#define GZIP_HPP_INCLUDE_GZIP_COMPRESS_HPP
+
+
 #include <gzip/config.hpp>
 
 // zlib
@@ -111,3 +115,5 @@ inline std::string compress(const char* data,
 }
 
 } // namespace gzip
+
+#endif // GZIP_HPP_INCLUDE_GZIP_COMPRESS_HPP

--- a/include/gzip/decompress.hpp
+++ b/include/gzip/decompress.hpp
@@ -1,3 +1,6 @@
+#ifndef GZIP_HPP_INCLUDE_GZIP_DECOMPRESS_HPP
+#define GZIP_HPP_INCLUDE_GZIP_DECOMPRESS_HPP
+
 #include <gzip/config.hpp>
 
 // zlib
@@ -103,3 +106,5 @@ inline std::string decompress(const char* data, std::size_t size)
 }
 
 } // namespace gzip
+
+#endif // GZIP_HPP_INCLUDE_GZIP_DECOMPRESS_HPP

--- a/include/gzip/utils.hpp
+++ b/include/gzip/utils.hpp
@@ -1,3 +1,6 @@
+#ifndef GZIP_HPP_INCLUDE_GZIP_UTILS_HPP
+#define GZIP_HPP_INCLUDE_GZIP_UTILS_HPP
+
 #include <cstdlib>
 
 namespace gzip {
@@ -20,3 +23,5 @@ inline bool is_compressed(const char* data, std::size_t size)
                (static_cast<uint8_t>(data[0]) == 0x1F && static_cast<uint8_t>(data[1]) == 0x8B));
 }
 } // namespace gzip
+
+#endif // GZIP_HPP_INCLUDE_GZIP_UTILS_HPP


### PR DESCRIPTION
The headers provided are generally missing include guards.
This led to many compiler issues in a few projects.

I've added basic include guards, so this doesn't happen in future and ugly hacks like this aren't needed:

```cpp
#ifndef GZIP_HPP_INCLUDED
#define GZIP_HPP_INCLUDED
#include "gzip/decompress.hpp"
#endif
```