### PR TITLE
utils.hpp: add a missing #include <cstdint>

### DIFF
--- a/include/gzip/utils.hpp
+++ b/include/gzip/utils.hpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <cstdlib>
 
 namespace gzip {


### PR DESCRIPTION
Fixes a compilation error when building with aarch64-linux-gnu-g++-14.